### PR TITLE
Add Web Speech API test page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -571,7 +571,7 @@ async def get_webrtc_realtime(request: Request):
         realtime_model = os.getenv("OPENAI_REALTIME_MODEL", "gpt-4o-realtime-preview-2024-12-17")
             
         return templates.TemplateResponse(
-            "webrtc_realtime.html", 
+            "webrtc_realtime.html",
             {
                 "request": request,
                 "characters": characters,
@@ -582,13 +582,19 @@ async def get_webrtc_realtime(request: Request):
         logger.error(f"Error rendering WebRTC Realtime page: {e}")
         # Fallback with minimal context
         return templates.TemplateResponse(
-            "webrtc_realtime.html", 
+            "webrtc_realtime.html",
             {
                 "request": request,
                 "characters": ["assistant"],
                 "realtime_model": "gpt-4o-realtime-preview-2024-12-17",  # Default fallback
             }
         )
+
+
+@app.get("/speech_test")
+async def speech_test(request: Request):
+    """Serve a simple Web Speech API test page."""
+    return templates.TemplateResponse("speech_test.html", {"request": request})
 
 @app.get("/api/character/{character_name}")
 async def get_character_prompt(character_name: str):

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -643,3 +643,22 @@ a:hover {
 .error-message.webrtc {
     text-align: left !important;
 }
+
+.btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 8px;
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.transcript-box {
+    border: 1px solid var(--border-color);
+    padding: 8px;
+    margin: 10px 0;
+    min-height: 100px;
+    width: 100%;
+    max-width: 500px;
+    background-color: var(--conversation-bg);
+}

--- a/app/static/js/speech_test.js
+++ b/app/static/js/speech_test.js
@@ -1,39 +1,65 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const startBtn = document.getElementById('start-rec');
-  const stopBtn = document.getElementById('stop-rec');
-  const resultEl = document.getElementById('transcript');
-  const speakBtn = document.getElementById('play-tts');
-  const inputEl = document.getElementById('tts-input');
+  // ---- 要素取得 ----
+  const sttLangSel = document.getElementById('stt-language-select');
+  const startBtn   = document.getElementById('start-rec');
+  const stopBtn    = document.getElementById('stop-rec');
+  const statusEl   = document.getElementById('stt-status');
+  const resultEl   = document.getElementById('transcript');
 
+  const ttsLangSel = document.getElementById('tts-language-select');
+  const rateInput  = document.getElementById('tts-rate');
+  const pitchInput = document.getElementById('tts-pitch');
+  const volInput   = document.getElementById('tts-volume');
+  const rateVal    = document.getElementById('rate-value');
+  const pitchVal   = document.getElementById('pitch-value');
+  const volVal     = document.getElementById('volume-value');
+  const ttsInput   = document.getElementById('tts-input');
+  const playBtn    = document.getElementById('play-tts');
+
+  // ---- 認識設定 ----
   const SpeechRec = window.SpeechRecognition || window.webkitSpeechRecognition;
-  if (SpeechRec) {
-    const recog = new SpeechRec();
-    recog.lang = 'ja-JP';
-    recog.continuous = true;
-    recog.interimResults = true;
+  const recog     = new SpeechRec();
+  recog.continuous     = true;
+  recog.interimResults = true;
 
-    recog.onresult = e => {
-      let finalT = '', interimT = '';
-      for (let i = e.resultIndex; i < e.results.length; i++) {
-        const transcript = e.results[i][0].transcript;
-        if (e.results[i].isFinal) {
-          finalT += transcript;
-        } else {
-          interimT += transcript;
-        }
-      }
-      resultEl.textContent = finalT || interimT;
-    };
+  recog.onstart = () => { statusEl.textContent = '認識中...'; };
+  recog.onend   = () => { statusEl.textContent = '待機中'; };
+  recog.onerror = e => { statusEl.textContent = `エラー: ${e.error}`; };
 
-    recog.onend = () => recog.start();
+  recog.onresult = e => {
+    let finalT = '', interimT = '';
+    for (let i = e.resultIndex; i < e.results.length; i++) {
+      const t = e.results[i][0].transcript;
+      if (e.results[i].isFinal) finalT += t;
+      else interimT += t;
+    }
+    resultEl.textContent = finalT || interimT;
+  };
 
-    startBtn.onclick = () => recog.start();
-    stopBtn.onclick = () => recog.stop();
-  }
+  startBtn.onclick = () => {
+    recog.lang = sttLangSel.value;
+    recog.start();
+  };
+  stopBtn.onclick  = () => { recog.stop(); };
 
-  speakBtn.onclick = () => {
-    const utt = new SpeechSynthesisUtterance(inputEl.value);
-    utt.lang = 'ja-JP';
+  // ---- 合成パラメータ同期 ----
+  rateInput.oninput  = () => { rateVal.textContent  = rateInput.value;  };
+  pitchInput.oninput = () => { pitchVal.textContent = pitchInput.value; };
+  volInput.oninput   = () => { volVal.textContent   = volInput.value;   };
+
+  // ---- 音声合成実行 ----
+  playBtn.onclick = () => {
+    const utt = new SpeechSynthesisUtterance(ttsInput.value);
+    utt.lang   = ttsLangSel.value;
+    utt.rate   = parseFloat(rateInput.value);
+    utt.pitch  = parseFloat(pitchInput.value);
+    utt.volume = parseFloat(volInput.value);
+    // 対応音声選択 (必要なら)
+    const voice = speechSynthesis.getVoices()
+                  .find(v => v.lang === utt.lang);
+    if (voice) utt.voice = voice;
+
     window.speechSynthesis.speak(utt);
   };
 });
+

--- a/app/static/js/speech_test.js
+++ b/app/static/js/speech_test.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const startBtn = document.getElementById('start-rec');
+  const stopBtn = document.getElementById('stop-rec');
+  const resultEl = document.getElementById('transcript');
+  const speakBtn = document.getElementById('play-tts');
+  const inputEl = document.getElementById('tts-input');
+
+  const SpeechRec = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (SpeechRec) {
+    const recog = new SpeechRec();
+    recog.lang = 'ja-JP';
+    recog.continuous = true;
+    recog.interimResults = true;
+
+    recog.onresult = e => {
+      let finalT = '', interimT = '';
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const transcript = e.results[i][0].transcript;
+        if (e.results[i].isFinal) {
+          finalT += transcript;
+        } else {
+          interimT += transcript;
+        }
+      }
+      resultEl.textContent = finalT || interimT;
+    };
+
+    recog.onend = () => recog.start();
+
+    startBtn.onclick = () => recog.start();
+    stopBtn.onclick = () => recog.stop();
+  }
+
+  speakBtn.onclick = () => {
+    const utt = new SpeechSynthesisUtterance(inputEl.value);
+    utt.lang = 'ja-JP';
+    window.speechSynthesis.speak(utt);
+  };
+});

--- a/app/templates/enhanced.html
+++ b/app/templates/enhanced.html
@@ -226,6 +226,7 @@
                     <li><a href="/">Dashboard</a></li>
                     <li><a href="/enhanced" class="active">Enhanced</a></li>
                     <li><a href="/webrtc_realtime">Realtime</a></li>
+                    <li><a href="/speech_test">Voice Test</a></li>
                 </ul>
             </nav>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -90,6 +90,7 @@
                     <li><a href="/" class="active">Dashboard</a></li>
                     <li><a href="/enhanced">Enhanced</a></li>
                     <li><a href="/webrtc_realtime">Realtime</a></li>
+                    <li><a href="/speech_test">Voice Test</a></li>
                 </ul>
             </nav>
         </div>

--- a/app/templates/speech_test.html
+++ b/app/templates/speech_test.html
@@ -1,36 +1,101 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Web Speech Test</title>
-    <link rel="stylesheet" href="/app/static/css/styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Web Speech Test</title>
+  <link rel="stylesheet" href="/app/static/css/styles.css" />
+  <style>
+    /* 必要なら styles.css に移してください */
+    .section { margin-bottom: 2rem; padding: 1rem; border: 1px solid #444; border-radius: 4px; }
+    .section h3 { margin-top: 0; }
+    .controls { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
+    .controls label { white-space: nowrap; }
+    .controls > * { margin-right: 0.5rem; }
+    .transcript-box { min-height: 4rem; padding: 0.5rem; background: #222; color: #fff; overflow-y: auto; }
+    .status { margin-top: 0.5rem; font-style: italic; }
+    .slider { vertical-align: middle; }
+  </style>
 </head>
 <body class="dark-mode">
-    <header>
-        <h1>
-            Voice Chat AI
-            <div id="mic-icon" class="mic-off">&#x1F399;</div>
-        </h1>
-        <div class="header-controls">
-            <nav class="main-nav">
-                <ul>
-                    <li><a href="/">Dashboard</a></li>
-                    <li><a href="/enhanced">Enhanced</a></li>
-                    <li><a href="/webrtc_realtime">Realtime</a></li>
-                    <li><a href="/speech_test" class="active">Voice Test</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
-    <main>
-        <h2>Web Speech API テスト</h2>
+  <header>
+    <h1>
+      Voice Chat AI
+      <div id="mic-icon" class="mic-off">&#x1F399;</div>
+    </h1>
+    <div class="header-controls">
+      <nav class="main-nav">
+        <ul>
+          <li><a href="/">Dashboard</a></li>
+          <li><a href="/enhanced">Enhanced</a></li>
+          <li><a href="/webrtc_realtime">Realtime</a></li>
+          <li><a href="/speech_test" class="active">Voice Test</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main class="p-4">
+    <h2>Web Speech API テスト</h2>
+
+    <!-- 音声認識セクション -->
+    <section id="stt-section" class="section">
+      <h3>音声認識</h3>
+      <div class="controls">
+        <label for="stt-language-select">言語：</label>
+        <select id="stt-language-select">
+          <option value="ja-JP" selected>日本語 (ja-JP)</option>
+          <option value="en-US">英語 (en-US)</option>
+        </select>
         <button id="start-rec">認識開始</button>
         <button id="stop-rec">認識停止</button>
-        <div id="transcript" class="transcript-box"></div>
-        <input type="text" id="tts-input" placeholder="読み上げテキスト" />
-        <button id="play-tts">再生</button>
-    </main>
-    <script src="/app/static/js/speech_test.js"></script>
+      </div>
+      <div id="stt-status" class="status">待機中</div>
+      <div id="transcript" class="transcript-box"></div>
+    </section>
+
+    <!-- 音声合成セクション -->
+    <section id="tts-section" class="section">
+      <h3>音声合成</h3>
+      <div class="controls">
+        <label for="tts-language-select">言語：</label>
+        <select id="tts-language-select">
+          <option value="ja-JP" selected>日本語 (ja-JP)</option>
+          <option value="en-US">英語 (en-US)</option>
+        </select>
+
+        <label for="tts-rate">スピード：</label>
+        <input type="range" id="tts-rate" class="slider" min="0.5" max="2.0" step="0.1" value="1.0">
+        <span id="rate-value">1.0</span>
+
+        <label for="tts-pitch">声の高さ：</label>
+        <input type="range" id="tts-pitch" class="slider" min="0.0" max="2.0" step="0.1" value="1.0">
+        <span id="pitch-value">1.0</span>
+
+        <label for="tts-volume">音量：</label>
+        <input type="range" id="tts-volume" class="slider" min="0.0" max="1.0" step="0.1" value="1.0">
+        <span id="volume-value">1.0</span>
+      </div>
+
+      <div class="controls" style="margin-top:1rem; flex-direction: column; align-items: stretch;">
+        <label for="tts-input">読み上げテキスト：</label>
+        <textarea id="tts-input" rows="2">読み上げテキストを再生しています。今日の天気は晴れです。</textarea>
+      </div>
+      <button id="play-tts">再生</button>
+    </section>
+  </main>
+
+  <!-- 説明・注意事項 -->
+  <aside class="info-box" style="margin:2rem; padding:1rem; border:1px solid #666; border-radius:4px; background:#1a1a1a; color:#ccc;">
+    <h3 style="margin-top:0; color:#fff;">機能紹介・注意事項</h3>
+    <ul style="list-style:disc; padding-left:1.5rem;">
+      <li>本ページはブラウザ標準の <strong>Web Speech API</strong> を使った音声認識（STT）と音声合成（TTS）のテスト用画面です。</li>
+      <li>動作は <strong>Chrome / Edge</strong> など Web Speech API 対応ブラウザに依存します（Safari/Firefox は一部機能が制限される場合があります）。</li>
+      <li>認識・合成はすべてクライアント（ブラウザ）内で完結し、<strong>無料</strong>でお試しいただけます。</li>
+      <li>認識精度や読み上げ品質が足りない場合は、<strong>Google Cloud Speech-to-Text</strong> や <strong>Azure Speech</strong>、あるいはサーバー連携の STT/TTS API への切り替えを検討してください。</li>
+      <li>本画面では LLM（自然言語生成）を挟まず、認識→再生のみを確認できます。AI 応答やチャット機能は未実装です。</li>
+    </ul>
+  </aside>
+
+  <script src="/app/static/js/speech_test.js"></script>
 </body>
 </html>

--- a/app/templates/speech_test.html
+++ b/app/templates/speech_test.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Web Speech Test</title>
+    <link rel="stylesheet" href="/app/static/css/styles.css">
+</head>
+<body class="dark-mode">
+    <header>
+        <h1>
+            Voice Chat AI
+            <div id="mic-icon" class="mic-off">&#x1F399;</div>
+        </h1>
+        <div class="header-controls">
+            <nav class="main-nav">
+                <ul>
+                    <li><a href="/">Dashboard</a></li>
+                    <li><a href="/enhanced">Enhanced</a></li>
+                    <li><a href="/webrtc_realtime">Realtime</a></li>
+                    <li><a href="/speech_test" class="active">Voice Test</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h2>Web Speech API テスト</h2>
+        <button id="start-rec">認識開始</button>
+        <button id="stop-rec">認識停止</button>
+        <div id="transcript" class="transcript-box"></div>
+        <input type="text" id="tts-input" placeholder="読み上げテキスト" />
+        <button id="play-tts">再生</button>
+    </main>
+    <script src="/app/static/js/speech_test.js"></script>
+</body>
+</html>

--- a/app/templates/webrtc_realtime.html
+++ b/app/templates/webrtc_realtime.html
@@ -615,6 +615,7 @@
                     <li><a href="/">Dashboard</a></li>
                     <li><a href="/enhanced">Enhanced</a></li>
                     <li><a href="/webrtc_realtime" class="active">Realtime</a></li>
+                    <li><a href="/speech_test">Voice Test</a></li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
## 要約
- FastAPI に新しい `/speech_test` ルートを実装する。
- Web Speech APIを試すための最小限のテストページを追加する。
- speech_test.js`で音声認識と音声合成をサポートする。
- シンプルなアイコンボタンとトランスクリプトボックスを追加
- サイトナビゲーションから新しいページをリンクする

https://github.com/take365/voice-chat-ai/issues/9#issue-3241705890

------
https://chatgpt.com/codex/tasks/task_e_6879faa981f88332baca0c4a4969e0e1