### PR TITLE
Add per-session OpenAI key input

### DIFF
--- a/app/enhanced_logic.py
+++ b/app/enhanced_logic.py
@@ -34,6 +34,15 @@ enhanced_transcription_model = os.getenv("OPENAI_TRANSCRIPTION_MODEL", "gpt-4o-m
 DEBUG_AUDIO_LEVELS = False  # Set to True to see audio level output in the console
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"  # Control detailed debug output
 
+current_api_key = None
+
+def set_session_api_key(key):
+    global current_api_key
+    current_api_key = key
+
+def get_session_api_key():
+    return current_api_key or os.getenv("OPENAI_API_KEY")
+
 # Quit phrases that will stop the conversation when detected
 QUIT_PHRASES = ["quit", "exit"]
 
@@ -136,7 +145,7 @@ async def enhanced_text_to_speech(text, detected_mood=None):
         enhanced_audio_filename = os.path.join(outputs_dir, "output_enhanced.wav")
         
         # Get OpenAI API key
-        openai_api_key = os.getenv("OPENAI_API_KEY")
+        openai_api_key = get_session_api_key()
         if not openai_api_key:
             print("API key missing. Please set OPENAI_API_KEY in your environment.")
             return
@@ -653,7 +662,7 @@ async def enhanced_chat_completion(prompt, system_message, mood_prompt, conversa
         import json
         
         # Get API key
-        openai_api_key = os.getenv("OPENAI_API_KEY")
+        openai_api_key = get_session_api_key()
         if not openai_api_key:
             return "API key missing. Please set OPENAI_API_KEY in your environment."
         
@@ -774,10 +783,13 @@ async def enhanced_chat_completion(prompt, system_message, mood_prompt, conversa
         print(f"Error in enhanced chat completion: {e}")
         return f"Error: {str(e)}"
 
-async def start_enhanced_conversation(character=None, speed=None, model=None, voice=None, ttsModel=None, transcriptionModel=None):
+async def start_enhanced_conversation(character=None, speed=None, model=None, voice=None, ttsModel=None, transcriptionModel=None, api_key=None):
     """Start a new enhanced conversation."""
     global enhanced_conversation_active, enhanced_conversation_thread, enhanced_speed, enhanced_voice, enhanced_model, enhanced_tts_model, enhanced_transcription_model, conversation_history
     
+    # Set API key for this session
+    set_session_api_key(api_key)
+
     # Import get_current_character at the top level to avoid shadowing
     from .shared import get_current_character as get_character
     

--- a/app/enhanced_logic.py
+++ b/app/enhanced_logic.py
@@ -120,9 +120,9 @@ async def record_enhanced_audio_and_transcribe():
     return await transcribe_audio(
         transcription_model=enhanced_transcription_model,
         use_local=False,  # Enhanced always uses OpenAI API
-        send_status_callback=send_message_to_enhanced_clients
+        send_status_callback=send_message_to_enhanced_clients,
+        api_key=get_session_api_key()
     )
-
 async def enhanced_text_to_speech(text, detected_mood=None):
     """Convert text to speech using the enhanced TTS model with emotional voice instructions."""
     try:

--- a/app/shared.py
+++ b/app/shared.py
@@ -10,6 +10,7 @@ load_dotenv()
 # WebSocket clients
 clients = set()
 active_client_status = {}  # Track status of websocket clients
+client_api_keys = {}
 
 # Shared state variables
 current_character = os.getenv("CHARACTER_NAME")  # Get from .env
@@ -48,6 +49,8 @@ def remove_client(client):
     clients.discard(client)
     if client in active_client_status:
         del active_client_status[client]
+    if client in client_api_keys:
+        del client_api_keys[client]
 
 def is_client_active(client):
     """Check if a client is active."""
@@ -56,6 +59,12 @@ def is_client_active(client):
 def set_client_inactive(client):
     """Mark a client as inactive."""
     active_client_status[client] = False
+
+def set_client_api_key(client, api_key):
+    client_api_keys[client] = api_key
+
+def get_client_api_key(client):
+    return client_api_keys.get(client)
 
 def clear_conversation_history():
     """Clear the conversation history."""

--- a/app/static/js/enhanced.js
+++ b/app/static/js/enhanced.js
@@ -336,7 +336,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${getApiKey()}`
             },
-            body: JSON.stringify({ ...settings, api_key: getApiKey() || undefined })
+            body: JSON.stringify({ ...settings, api_key: getApiKey() })
         })
         .then(response => response.json())
         .then(data => {

--- a/app/static/js/enhanced.js
+++ b/app/static/js/enhanced.js
@@ -16,6 +16,11 @@ document.addEventListener("DOMContentLoaded", () => {
     const modelSelect = document.getElementById('modelSelect');
     const ttsModelSelect = document.getElementById('ttsModelSelect');
     const transcriptionModelSelect = document.getElementById('transcriptionModelSelect');
+    const apiKeyInput = document.getElementById('openai-api-key');
+
+    function getApiKey() {
+        return apiKeyInput ? apiKeyInput.value.trim() : '';
+    }
 
     // Default speed value (since we removed the speedSelect dropdown)
     const defaultSpeed = "1.0";
@@ -42,6 +47,10 @@ document.addEventListener("DOMContentLoaded", () => {
             startBtn.disabled = false;
             reconnectAttempts = 0; // Reset reconnect counter on successful connection
             displayMessage("Connected to server", "system-message");
+            const key = getApiKey();
+            if (key) {
+                websocket.send(JSON.stringify({ action: 'set_api_key', api_key: key }));
+            }
         };
         
         websocket.onmessage = function(event) {
@@ -325,8 +334,9 @@ document.addEventListener("DOMContentLoaded", () => {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'Authorization': `Bearer ${getApiKey()}`
             },
-            body: JSON.stringify(settings)
+            body: JSON.stringify({ ...settings, api_key: getApiKey() || undefined })
         })
         .then(response => response.json())
         .then(data => {

--- a/app/static/js/webrtc_realtime.js
+++ b/app/static/js/webrtc_realtime.js
@@ -19,6 +19,11 @@ document.addEventListener("DOMContentLoaded", function() {
     const aiVoiceVisualization = document.getElementById('aiVoiceVisualization');
     const waitingIndicator = document.getElementById('waitingIndicator');
     const themeToggle = document.getElementById('theme-toggle');
+    const apiKeyInput = document.getElementById('openai-api-key');
+
+    function getApiKey() {
+        return apiKeyInput ? apiKeyInput.value.trim() : '';
+    }
     
     // Global state
     let peerConnection = null;
@@ -278,7 +283,11 @@ document.addEventListener("DOMContentLoaded", function() {
             
             console.log("Fetching ephemeral key...");
             // Get ephemeral key from server
-            const response = await fetch('/openai_ephemeral_key');
+            const response = await fetch('/openai_ephemeral_key', {
+                headers: {
+                    'Authorization': `Bearer ${getApiKey()}`
+                }
+            });
             console.log("Ephemeral key response status:", response.status);
             if (!response.ok) {
                 throw new Error(`Failed to get ephemeral key: ${response.status} - ${response.statusText}`);
@@ -410,7 +419,8 @@ document.addEventListener("DOMContentLoaded", function() {
                     method: "POST",
                     body: sdp,
                     headers: {
-                        "Content-Type": "application/sdp"
+                        "Content-Type": "application/sdp",
+                        "Authorization": `Bearer ${getApiKey()}`
                     }
                 });
                 
@@ -766,7 +776,11 @@ document.addEventListener("DOMContentLoaded", function() {
     
     // Fetch available characters
     function fetchCharacters() {
-        fetch('/characters')
+        fetch('/characters', {
+            headers: {
+                'Authorization': `Bearer ${getApiKey()}`
+            }
+        })
             .then(response => response.json())
             .then(data => {
                 characterSelect.innerHTML = '';
@@ -793,7 +807,11 @@ document.addEventListener("DOMContentLoaded", function() {
     async function fetchCharacterPrompt(characterName) {
         debugLog(`Fetching character prompt for: ${characterName}`, "info");
         try {
-            const response = await fetch(`/api/character/${characterName}`);
+            const response = await fetch(`/api/character/${characterName}`, {
+                headers: {
+                    'Authorization': `Bearer ${getApiKey()}`
+                }
+            });
             if (!response.ok) {
                 throw new Error(`Failed to fetch character prompt: ${response.status} ${response.statusText}`);
             }

--- a/app/templates/enhanced.html
+++ b/app/templates/enhanced.html
@@ -14,7 +14,13 @@
         .control-button {
             margin: 0 8px;
         }
-        
+        /* 警告文スタイル */
+        .api-key-warning {
+            margin: 8px 0;
+            text-align: center;
+            font-size: 0.8rem;
+            color: #d9534f;
+        }
         /* Match button size with main page */
         .controls {
             display: flex;
@@ -247,7 +253,9 @@
             <input type="password" id="openai-api-key" placeholder="sk-...">
         </label>
     </div>
-
+    <div class="api-key-warning">
+        <p>This screen is provided for evaluation purposes only and is not strictly managed. There is a risk of API key leakage or misuse. Please generate a new API key before use and delete it after use.</p>
+    </div>
     <main>
         <div id="conversation" class="conversation-container">
             <div id="messages"></div>

--- a/app/templates/enhanced.html
+++ b/app/templates/enhanced.html
@@ -198,6 +198,16 @@
         .header-controls #download-button {
             margin-top: 12px;
         }
+
+        .api-key-input {
+            margin: 10px 0;
+            text-align: center;
+        }
+
+        .api-key-input input {
+            padding: 4px;
+            width: 200px;
+        }
     </style>
 </head>
 <body class="dark-mode">
@@ -231,6 +241,12 @@
             </nav>
         </div>
     </header>
+
+    <div class="api-key-input">
+        <label>OpenAI API キー（任意）:
+            <input type="password" id="openai-api-key" placeholder="sk-...">
+        </label>
+    </div>
 
     <main>
         <div id="conversation" class="conversation-container">

--- a/app/templates/webrtc_realtime.html
+++ b/app/templates/webrtc_realtime.html
@@ -17,7 +17,13 @@
             margin: 15px 0;
             gap: 6px;
         }
-        
+        /* 警告文スタイル */
+        .api-key-warning {
+            margin: 8px 0;
+            text-align: center;
+            font-size: 0.8rem;
+            color: #d9534f;
+        }        
         .voice-bar {
             width: 6px;
             height: 5px; /* Default height when not active */
@@ -636,7 +642,9 @@
             <input type="password" id="openai-api-key" placeholder="sk-...">
         </label>
     </div>
-
+    <div class="api-key-warning">
+        <p>This screen is provided for evaluation purposes only and is not strictly managed. There is a risk of API key leakage or misuse. Please generate a new API key before use and delete it after use.</p>
+    </div>
     <main>
         <div class="container">
             <h2>OpenAI Realtime webRTC</h2>

--- a/app/templates/webrtc_realtime.html
+++ b/app/templates/webrtc_realtime.html
@@ -596,6 +596,16 @@
         .header-controls #theme-toggle {
             margin-top: 10px;
         }
+
+        .api-key-input {
+            margin: 10px 0;
+            text-align: center;
+        }
+
+        .api-key-input input {
+            padding: 4px;
+            width: 200px;
+        }
     </style>
 </head>
 <body class="dark-mode">
@@ -620,7 +630,13 @@
             </nav>
         </div>
     </header>
-    
+
+    <div class="api-key-input">
+        <label>OpenAI API キー（任意）:
+            <input type="password" id="openai-api-key" placeholder="sk-...">
+        </label>
+    </div>
+
     <main>
         <div class="container">
             <h2>OpenAI Realtime webRTC</h2>

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -77,9 +77,10 @@ def transcribe_with_whisper(audio_file):
         transcription += segment.text + " "
     return transcription.strip()
 
-async def transcribe_with_openai_api(audio_file, model="gpt-4o-mini-transcribe"):
+async def transcribe_with_openai_api(audio_file, model="gpt-4o-mini-transcribe", api_key: str | None = None):
     """Transcribe audio using OpenAI's API"""
-    if not OPENAI_API_KEY:
+    key = api_key or OPENAI_API_KEY
+    if not key:
         raise ValueError("API key missing. Please set OPENAI_API_KEY in your environment.")
     
     # Make the API call to OpenAI
@@ -98,7 +99,7 @@ async def transcribe_with_openai_api(audio_file, model="gpt-4o-mini-transcribe")
             form_data.add_field('language', LANGUAGE)
             
             headers = {
-                "Authorization": f"Bearer {OPENAI_API_KEY}"
+                "Authorization": f"Bearer {key}"
             }
             
             async with session.post(api_url, data=form_data, headers=headers) as response:

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -328,7 +328,10 @@ async def send_status_message(callback, message):
     if callback:
         await callback(message)
 
-async def transcribe_audio(transcription_model="gpt-4o-mini-transcribe", use_local=False, send_status_callback=None):
+#async def transcribe_audio(transcription_model="gpt-4o-mini-transcribe", use_local=False, send_status_callback=None):
+async def transcribe_audio(
+    transcription_model="gpt-4o-mini-transcribe", use_local=False, send_status_callback=None, api_key: str | None = None
+):
     """Main function to record audio and transcribe it
     
     Args:
@@ -362,8 +365,9 @@ async def transcribe_audio(transcription_model="gpt-4o-mini-transcribe", use_loc
             transcription = transcribe_with_whisper(temp_filename)
         else:
             # Use OpenAI API
-            transcription = await transcribe_with_openai_api(temp_filename, transcription_model)
-            
+            #transcription = await transcribe_with_openai_api(temp_filename, transcription_model)
+            # Use OpenAI API (api_key を渡す)
+            transcription = await transcribe_with_openai_api(temp_filename, transcription_model, api_key)            
         # Clean up temp file
         try:
             os.unlink(temp_filename)


### PR DESCRIPTION
## 要約
- 拡張ページとリアルタイムページにオプションでAPIキーフィールドを追加する。
- リクエストやウェブソケット経由でAPIキーを送信
- バックエンドエンドポイントがヘッダーからキーを優先できるようにする。
- 拡張ウェブソケット用にクライアントごとのキーを保存する

https://github.com/take365/voice-chat-ai/issues/15
------
https://chatgpt.com/codex/tasks/task_e_687a18f8d0748332a8c35c52ca016387